### PR TITLE
Fix: Remove fuse token from fuse chain list

### DIFF
--- a/build/fuseswap-default.tokenlist.json
+++ b/build/fuseswap-default.tokenlist.json
@@ -1,6 +1,6 @@
 {
   "name": "Fuse Token List",
-  "timestamp": "2020-12-06T20:08:02.763Z",
+  "timestamp": "2020-12-07T10:55:49.647Z",
   "version": {
     "major": 2,
     "minor": 2,

--- a/build/fuseswap-default.tokenlist.json
+++ b/build/fuseswap-default.tokenlist.json
@@ -1,6 +1,6 @@
 {
   "name": "Fuse Token List",
-  "timestamp": "2020-12-06T16:08:23.698Z",
+  "timestamp": "2020-12-06T20:08:02.763Z",
   "version": {
     "major": 2,
     "minor": 2,
@@ -1085,14 +1085,6 @@
       "decimals": 6,
       "chainId": 122,
       "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x9Cb2f26A23b8d89973F08c957C4d7cdf75CD341c/logo.png"
-    },
-    {
-      "name": "Fuse Token on Fuse",
-      "address": "0x714005Da6A90F59dD2cF74560ecF4A4BeD5F088A",
-      "symbol": "FUSE",
-      "decimals": 18,
-      "chainId": 122,
-      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x970B9bB2C0444F5E81e9d0eFb84C8ccdcdcAf84d/logo.png"
     },
     {
       "name": "GoodDollar",

--- a/src/buildFuseList.js
+++ b/src/buildFuseList.js
@@ -21,7 +21,7 @@ async function buildList() {
   const fuseTokens = await fetchBridgedTokens(foreignAddresses);
   const bridgedFuseTokens = mainnet.map(mainnetToken => {
     const fuseToken = fuseTokens.find(token => token.foreignAddress == mainnetToken.address.toLowerCase());
-    if (fuseToken) {
+    if (fuseToken && fuseToken.symbol !== 'FUSE') {
       delete fuseToken.foreignAddress
       return {...mainnetToken, ...fuseToken, address: toChecksumAddress(fuseToken.address), chainId: 122 };
     }

--- a/src/buildFuseList.js
+++ b/src/buildFuseList.js
@@ -21,7 +21,7 @@ async function buildList() {
   const fuseTokens = await fetchBridgedTokens(foreignAddresses);
   const bridgedFuseTokens = mainnet.map(mainnetToken => {
     const fuseToken = fuseTokens.find(token => token.foreignAddress == mainnetToken.address.toLowerCase());
-    if (fuseToken && fuseToken.symbol !== 'FUSE') {
+    if (fuseToken && fuseToken.address !== '0x714005da6a90f59dd2cf74560ecf4a4bed5f088a') {
       delete fuseToken.foreignAddress
       return {...mainnetToken, ...fuseToken, address: toChecksumAddress(fuseToken.address), chainId: 122 };
     }


### PR DESCRIPTION
PR Notes:
- Remove fuse from fuse chain list since its the native currency on fuse no need to add it to the list.

Upgrade: MAJOR